### PR TITLE
change how IsErrorCode check error with errors.As

### DIFF
--- a/error.go
+++ b/error.go
@@ -22,8 +22,11 @@ type sqlState interface {
 
 // IsErrorCode checks is error has given code
 func IsErrorCode(err error, code string) bool {
-	sErr, ok := err.(sqlState)
-	return ok && sErr.SQLState() == code
+	var sErr sqlState
+	if errors.As(err, &sErr) {
+		return sErr.SQLState() == code
+	}
+	return false
 }
 
 // IsErrorClass checks is error has given class


### PR DESCRIPTION
This pull request attempts to address an edge case where IsErrorCode receives a wrapped error. For example, the 'ent' package returns an error like this:

```go
if err := c.batchInsert(ctx, tx, insert); err != nil {
    return fmt.Errorf("insert nodes to table %q: %w", c.Nodes[0].Table, err)
}
```

It is necessary to use errors.As to properly check if the error can be cast to the sqlState interface or not.